### PR TITLE
Add MacPorts installation instructions

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -12,6 +12,7 @@ date: 2025-01-01
 - [Reproducible Builds](#reproducible-builds)
 - [Community Maintained Packages](#community-maintained-packages)
   - [Brew](#brew)
+  - [MacPorts](#macports)
   - [RPM](#rpm)
   - [Snap](#snap)
   - [Wolfi](#wolfi)
@@ -199,6 +200,14 @@ The following methods to install regclient are maintained by community contribut
 
 ```shell
 brew install regclient
+```
+
+### MacPorts
+
+<https://ports.macports.org/port/regclient>
+
+```shell
+sudo port install regclient
 ```
 
 ### RPM


### PR DESCRIPTION
regclient was recently published as a package in the MacPorts ports tree. This adds instructions to the `install` page for installing it using MacPorts.