### PR TITLE
Chore: Version bump and linting

### DIFF
--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -1,5 +1,5 @@
-{"name":"makefile-geekdoc-theme","key":"https://github.com/thegeeklab/hugo-geekdoc.git","version":"v1.3.0"}
-{"name":"makefile-hugo","key":"https://github.com/gohugoio/hugo.git","version":"v0.142.0"}
-{"name":"makefile-markdown-lint","key":"docker.io/davidanson/markdownlint-cli2","version":"v0.17.2"}
-{"name":"netlify-hugo","key":"https://github.com/gohugoio/hugo.git","version":"0.142.0"}
-{"name":"netlify-node","key":"https://github.com/nodejs/node.git","version":"23"}
+{"name":"makefile-geekdoc-theme","key":"https://github.com/thegeeklab/hugo-geekdoc.git","version":"v1.6.1"}
+{"name":"makefile-hugo","key":"https://github.com/gohugoio/hugo.git","version":"v0.148.2"}
+{"name":"makefile-markdown-lint","key":"docker.io/davidanson/markdownlint-cli2","version":"v0.18.1"}
+{"name":"netlify-hugo","key":"https://github.com/gohugoio/hugo.git","version":"0.148.2"}
+{"name":"netlify-node","key":"https://github.com/nodejs/node.git","version":"24"}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER?=$(shell command -v docker 2>/dev/null)
 HUGO?=$(shell command -v hugo 2>/dev/null)
 HUGO_CMD_VER:=$(shell [ -x "$(HUGO)" ] && echo "$$($(HUGO) version | awk '{print $$2}')" || echo "0")
-HUGO_VERSION?=v0.142.0
+HUGO_VERSION?=v0.148.2
 HUGO_CONTAINER?=ghcr.io/gohugoio/hugo:$(HUGO_VERSION)
 ifneq "$(HUGO_CMD_VER)" "$(HUGO_VERSION)"
 	ifneq "$(strip $(DOCKER))" ""
@@ -11,10 +11,10 @@ ifneq "$(HUGO_CMD_VER)" "$(HUGO_VERSION)"
 			$(HUGO_CONTAINER)
 	endif
 endif
-THEME_VERSION?=v1.3.0
+THEME_VERSION?=v1.6.1
 THEME?=hugo-geekdoc
 CLI_CMDS?=regctl regsync regbot
-MARKDOWN_LINT_VER?=v0.17.2
+MARKDOWN_LINT_VER?=v0.18.1
 VER_BUMP?=$(shell command -v version-bump 2>/dev/null)
 VER_BUMP_CONTAINER?=sudobmitch/version-bump:edge
 ifeq "$(strip $(VER_BUMP))" ''
@@ -52,7 +52,7 @@ lint: lint-md ## Run all linting
 .PHONY: lint-md
 lint-md: ## Run linting for markdown
 	docker run --rm -v "$(PWD):/workdir:ro" davidanson/markdownlint-cli2:$(MARKDOWN_LINT_VER) \
-	  "**/*.md" "#public"
+	  "**/*.md" "#public" "#content/cli/regbot/completion/" "#content/cli/regctl/completion/" "#content/cli/regsync/completion/"
 
 .PHONY: cli-docs
 cli-docs: $(addprefix cli-docs-,$(CLI_CMDS)) ## Update CLI documentation

--- a/content/cli/regctl/image/check-base/_index.md
+++ b/content/cli/regctl/image/check-base/_index.md
@@ -10,7 +10,7 @@ Check the base image (found using annotations or an option).
 If the base name is not provided, annotations will be checked in the image.
 If the digest is available, this checks if that matches the base name.
 If the digest is not available, layers of each manifest are compared.
-If the layers match, the config (history and roots) are optionally compared.	
+If the layers match, the config (history and roots) are optionally compared.
 If the base image does not match, the command exits with a non-zero status.
 
 ```shell

--- a/content/cli/regctl/image/delete/_index.md
+++ b/content/cli/regctl/image/delete/_index.md
@@ -7,7 +7,7 @@ warning: Auto generated content
 ## Synopsis
 
 Delete a manifest. This will delete the manifest, and all tags pointing to that
-manifest. You must specify a digest, not a tag on this command (e.g. 
+manifest. You must specify a digest, not a tag on this command (e.g.
 image_name@sha256:1234abc...). It is up to the registry whether the delete
 API is supported. Additionally, registries may garbage collect the filesystem
 layers (blobs) separately or not at all. See also the "tag delete" command.

--- a/content/cli/regctl/manifest/delete/_index.md
+++ b/content/cli/regctl/manifest/delete/_index.md
@@ -7,7 +7,7 @@ warning: Auto generated content
 ## Synopsis
 
 Delete a manifest. This will delete the manifest, and all tags pointing to that
-manifest. You must specify a digest, not a tag on this command (e.g. 
+manifest. You must specify a digest, not a tag on this command (e.g.
 image_name@sha256:1234abc...). It is up to the registry whether the delete
 API is supported. Additionally, registries may garbage collect the filesystem
 layers (blobs) separately or not at all. See also the "tag delete" command.

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -258,4 +258,3 @@ snap install regclient
 ```shell
 apk add regclient
 ```
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
-HUGO_VERSION = "0.142.0"
-NODE_VERSION = "23"
+HUGO_VERSION = "0.148.2"
+NODE_VERSION = "24"
 TZ = "America/Los_Angeles"
 
 [build]


### PR DESCRIPTION
Routine version bump of Hugo and theme, plus linting fixes from the latest release of markdownlint-cli2.